### PR TITLE
Remove plugin folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ packadd nvim-ale-diagnostic
 " or your favorite package manager here
 ```
 
-Then, put the following in a Lua file at `nvim/lua/lsp-ale-diagnostic/init.lua`:
+Then, put the following in a Lua file at `nvim/lua/lsp/init.lua`:
 
 ```lua
+require("nvim-ale-diagnostic")
+
 vim.lsp.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(
   vim.lsp.diagnostic.on_publish_diagnostics, {
     underline = false,
@@ -32,11 +34,7 @@ vim.lsp.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(
 )
 ```
 
-Then source it from your `init.vim` file:
-
-```
-lua require("nvim-ale-diagnostic")
-```
+For an example of this in action, check out [my dotfiles](https://github.com/nathunsmitty/.config/blob/main/nvim/lua/lsp/init.lua).
 
 ## Notes
 

--- a/plugin/diagnostic.vim
+++ b/plugin/diagnostic.vim
@@ -1,1 +1,0 @@
-lua require('nvim-ale-diagnostic')


### PR DESCRIPTION
Previously, we had this `plugin/diagnostic.vim` file that loaded the lua part of this plugin even though we recommend loading the lua part directly in the readme. This clarifies the lua part and removes the vimscript file in favor of loading directly in lua. 