### PR TITLE
Add original_clear to vim.lsp.diagnostic

### DIFF
--- a/lua/nvim-ale-diagnostic.lua
+++ b/lua/nvim-ale-diagnostic.lua
@@ -5,9 +5,9 @@ local ale_diagnostic_severity_map = {
   [vim.lsp.protocol.DiagnosticSeverity.Hint] = "H";
 }
 
-local orginal_clear = vim.lsp.diagnostic.clear
+vim.lsp.diagnostic.original_clear = vim.lsp.diagnostic.clear
 vim.lsp.diagnostic.clear = function(bufnr, client_id, diagnostic_ns, sign_ns)
-  orginal_clear(bufnr, client_id, diagnostic_ns, sign_ns)
+  vim.lsp.diagnostic.original_clear(bufnr, client_id, diagnostic_ns, sign_ns)
   -- Clear ALE
   vim.api.nvim_call_function('ale#other_source#ShowResults', {bufnr, "nvim-lsp", {}})
 end


### PR DESCRIPTION
Rather than have `orginal_clear` be a local variable, I think it makes more sense to stick it on `vim.lsp.diagnostic` in case it needs to be used elsewhere.